### PR TITLE
Recover from missing spaces before annotation/attribute

### DIFF
--- a/parser/src/diagnostic.rs
+++ b/parser/src/diagnostic.rs
@@ -79,10 +79,6 @@ diagnostics! {
       message: ("Markup has option after attribute (at {:?})", option.span()),
       span: option.span(),
     },
-    MarkupMissingSpaceBeforeAttribute { attribute: Attribute<'a> } => {
-      message: ("Markup has attribute with missing leading space (at {:?})", attribute.span()),
-      span: attribute.span(),
-    },
     UnterminatedQuoted { span: Span } => {
       message: ("Quoted string is missing a closing quote (at {:?})", span),
       span: *span,
@@ -118,6 +114,14 @@ diagnostics! {
     InvalidClosingBrace { brace_loc: Location } => {
       message: ("'}}' in simple messages must be escaped (at {:?})", brace_loc),
       span: Span::new(*brace_loc..(*brace_loc + '}')),
+    },
+    MissingSpaceBeforeAnnotation { span: Span } => {
+      message: ("Annotations must be preceeded by a leading space (at {:?})", *span),
+      span: *span,
+    },
+    MissingSpaceBeforeAttribute { span: Span } => {
+      message: ("Attributes must be preceeded by a leading space (at {:?})", *span),
+      span: *span,
     },
   }
 }

--- a/parser/tests/parser/expressions/attributes/missing_leading_space.mf2
+++ b/parser/tests/parser/expressions/attributes/missing_leading_space.mf2
@@ -2,22 +2,20 @@
 === spans ===
                     {1@foo}
 SimpleMessage       ^^^^^^^
-LiteralExpression   ^^
+LiteralExpression   ^^^^^^^
 Number               ^
 Number.integral      ^
-Text                  ^^^^^
+Attribute             ^^^^
+Identifier             ^^^
 === diagnostics ===
-Placeholder is missing a closing brace (at @0..2)
+Attributes must be preceeded by a leading space (at @2..6)
   {1@foo}
-  ^^
-'}' in simple messages must be escaped (at @6)
-  {1@foo}
-        ^
+    ^^^^
 === ast ===
 SimpleMessage {
     parts: [
         LiteralExpression {
-            span: @0..2,
+            span: @0..7,
             literal: Number {
                 start: @1,
                 raw: "1",
@@ -27,11 +25,17 @@ SimpleMessage {
                 exponent_len: None,
             },
             annotation: None,
-            attributes: [],
-        },
-        Text {
-            start: @2,
-            content: "@foo}",
+            attributes: [
+                Attribute {
+                    start: @2,
+                    key: Identifier {
+                        start: @3,
+                        namespace: None,
+                        name: "foo",
+                    },
+                    value: None,
+                },
+            ],
         },
     ],
 }

--- a/parser/tests/parser/expressions/attributes/multiple_missing_space.mf2
+++ b/parser/tests/parser/expressions/attributes/multiple_missing_space.mf2
@@ -2,24 +2,23 @@
 === spans ===
                     {1 @foo@hello=world}
 SimpleMessage       ^^^^^^^^^^^^^^^^^^^^
-LiteralExpression   ^^^^^^^
+LiteralExpression   ^^^^^^^^^^^^^^^^^^^^
 Number               ^
 Number.integral      ^
 Attribute              ^^^^
 Identifier              ^^^
-Text                       ^^^^^^^^^^^^^
+Attribute                  ^^^^^^^^^^^^
+Identifier                  ^^^^^
+Text                              ^^^^^
 === diagnostics ===
-Placeholder is missing a closing brace (at @0..7)
+Attributes must be preceeded by a leading space (at @7..19)
   {1 @foo@hello=world}
-  ^^^^^^^
-'}' in simple messages must be escaped (at @19)
-  {1 @foo@hello=world}
-                     ^
+         ^^^^^^^^^^^^
 === ast ===
 SimpleMessage {
     parts: [
         LiteralExpression {
-            span: @0..7,
+            span: @0..20,
             literal: Number {
                 start: @1,
                 raw: "1",
@@ -39,11 +38,21 @@ SimpleMessage {
                     },
                     value: None,
                 },
+                Attribute {
+                    start: @7,
+                    key: Identifier {
+                        start: @8,
+                        namespace: None,
+                        name: "hello",
+                    },
+                    value: Some(
+                        Text {
+                            start: @14,
+                            content: "world",
+                        },
+                    ),
+                },
             ],
-        },
-        Text {
-            start: @7,
-            content: "@hello=world}",
         },
     ],
 }

--- a/parser/tests/parser/expressions/function/missing_space_after_var.mf2
+++ b/parser/tests/parser/expressions/function/missing_space_after_var.mf2
@@ -2,31 +2,35 @@
 === spans ===
                     {$a:b}
 SimpleMessage       ^^^^^^
-VariableExpression  ^^^
+VariableExpression  ^^^^^^
 Variable             ^^
-Text                   ^^^
+Function               ^^
+Identifier              ^
 === diagnostics ===
-Placeholder is missing a closing brace (at @0..3)
+Annotations must be preceeded by a leading space (at @3..5)
   {$a:b}
-  ^^^
-'}' in simple messages must be escaped (at @5)
-  {$a:b}
-       ^
+     ^^
 === ast ===
 SimpleMessage {
     parts: [
         VariableExpression {
-            span: @0..3,
+            span: @0..6,
             variable: Variable {
                 start: @1,
                 name: "a",
             },
-            annotation: None,
+            annotation: Some(
+                Function {
+                    start: @3,
+                    id: Identifier {
+                        start: @4,
+                        namespace: None,
+                        name: "b",
+                    },
+                    options: [],
+                },
+            ),
             attributes: [],
-        },
-        Text {
-            start: @3,
-            content: ":b}",
         },
     ],
 }

--- a/parser/tests/parser/markup/attributes/missing_space_before.mf2
+++ b/parser/tests/parser/markup/attributes/missing_space_before.mf2
@@ -9,7 +9,7 @@ Identifier               ^^^^
 Number                        ^
 Number.integral               ^
 === diagnostics ===
-Markup has attribute with missing leading space (at @4..11)
+Attributes must be preceeded by a leading space (at @4..11)
   {#el@attr=1}
       ^^^^^^^
 === ast ===

--- a/parser/tests/parser/markup/attributes/missing_space_before_multiple_1.mf2
+++ b/parser/tests/parser/markup/attributes/missing_space_before_multiple_1.mf2
@@ -9,7 +9,7 @@ Identifier                ^^^^^
 Attribute                      ^^^^^^
 Identifier                      ^^^^^
 === diagnostics ===
-Markup has attribute with missing leading space (at @11..17)
+Attributes must be preceeded by a leading space (at @11..17)
   {#el @attr1@attr2 }
              ^^^^^^
 === ast ===

--- a/parser/tests/parser/markup/attributes/missing_space_before_multiple_2.mf2
+++ b/parser/tests/parser/markup/attributes/missing_space_before_multiple_2.mf2
@@ -10,7 +10,7 @@ Text                              ^^^
 Attribute                            ^^^^^^
 Identifier                            ^^^^^
 === diagnostics ===
-Markup has attribute with missing leading space (at @17..23)
+Attributes must be preceeded by a leading space (at @17..23)
   {#el @attr1 = val@attr2 }
                    ^^^^^^
 === ast ===


### PR DESCRIPTION
This was already working for markup.