### PR TITLE
Add support for renaming variables

### DIFF
--- a/lsp/src/document.rs
+++ b/lsp/src/document.rs
@@ -13,6 +13,7 @@ use yoke::Yoke;
 use yoke::Yokeable;
 
 use crate::diagnostics::Diagnostic;
+use crate::scope::Scope;
 use crate::scope::ScopeVisitor;
 
 pub struct Document {
@@ -26,6 +27,7 @@ pub struct ParsedDocument<'text> {
   pub ast: Message<'text>,
   pub diagnostics: Vec<Diagnostic<'text>>,
   pub info: SourceTextInfo<'text>,
+  pub scope: Scope<'text>,
 }
 
 impl Document {
@@ -38,15 +40,16 @@ impl Document {
         .map(Diagnostic::Parser)
         .collect();
 
-      let diagnostics = {
+      let (scope, diagnostics) = {
         let mut scope_visitor = ScopeVisitor::new(diagnostics);
         scope_visitor.visit_message(&ast);
-        scope_visitor.diagnostics
+        (scope_visitor.variables, scope_visitor.diagnostics)
       };
 
       ParsedDocument {
         ast,
         info,
+        scope,
         diagnostics,
       }
     });

--- a/lsp/src/main.rs
+++ b/lsp/src/main.rs
@@ -251,7 +251,7 @@ impl LanguageServer for Server<'_> {
       .expect("Variable not found in scope");
 
     if !is_valid_name(&params.new_name) {
-      return Err(anyhow::Error::msg("Invalid variable name"));
+      return Err(anyhow::anyhow!("Invalid variable name."));
     }
 
     let mut changes = Vec::new();

--- a/lsp/src/main.rs
+++ b/lsp/src/main.rs
@@ -230,12 +230,12 @@ impl LanguageServer for Server<'_> {
 
     let maybe_document = self.documents.get(&text_document.uri);
     let Some(document) = maybe_document else {
-      return Err(anyhow::Error::msg("Document not found"));
+      return Err(anyhow::anyhow!("Document not found."));
     };
 
     let Some(AnyNode::Variable(node)) = document.find_node(position) else {
-      return Err(anyhow::Error::msg(
-        "No variable to rename at the given position",
+      return Err(anyhow::anyhow!(
+        "No variable to rename at the given position.",
       ));
     };
 

--- a/lsp/src/main.rs
+++ b/lsp/src/main.rs
@@ -226,16 +226,25 @@ impl LanguageServer for Server<'_> {
 
     let maybe_document = self.documents.get(&text_document.uri);
     let Some(document) = maybe_document else {
-      return Ok(None);
+      return Err(anyhow::Error::msg("Document not found"));
     };
 
     let Some(AnyNode::Variable(node)) = document.find_node(position) else {
-      return Ok(None);
+      return Err(anyhow::Error::msg(
+        "No variable to rename at the given position",
+      ));
     };
 
-    let Some(usage) = document.parsed.get().scope.get(node.name) else {
+    if node.name == params.new_name {
       return Ok(None);
-    };
+    }
+
+    let usage = document
+      .parsed
+      .get()
+      .scope
+      .get(node.name)
+      .expect("Variable not found in scope");
 
     let mut changes = Vec::new();
 

--- a/lsp/src/protocol.rs
+++ b/lsp/src/protocol.rs
@@ -5,6 +5,7 @@ use lsp_types::notification::DidOpenTextDocument;
 use lsp_types::notification::PublishDiagnostics;
 use lsp_types::request::CodeActionRequest;
 use lsp_types::request::HoverRequest;
+use lsp_types::request::PrepareRenameRequest;
 use lsp_types::request::Rename as RenameRequest;
 
 pub struct LanguageClient<'a> {
@@ -149,6 +150,7 @@ language_server! {
     hover: HoverRequest,
     code_action: CodeActionRequest,
     rename: RenameRequest,
+    prepare_rename: PrepareRenameRequest,
   }
 }
 

--- a/lsp/src/protocol.rs
+++ b/lsp/src/protocol.rs
@@ -101,9 +101,8 @@ macro_rules! language_server {
                     }
                   },
                   Err(err) => {
-                    let message = format!("Error handling request {}: {:?}", <$request_typ as lsp_types::request::Request>::METHOD, err);
                     const REQUEST_FAILED_ERROR_CODE: i32 = -32803;
-                    lsp_server::Response::new_err(request.id, REQUEST_FAILED_ERROR_CODE, message)
+                    lsp_server::Response::new_err(request.id, REQUEST_FAILED_ERROR_CODE, err.to_string())
                   }
                 }
               }

--- a/lsp/src/protocol.rs
+++ b/lsp/src/protocol.rs
@@ -5,6 +5,7 @@ use lsp_types::notification::DidOpenTextDocument;
 use lsp_types::notification::PublishDiagnostics;
 use lsp_types::request::CodeActionRequest;
 use lsp_types::request::HoverRequest;
+use lsp_types::request::Rename as RenameRequest;
 
 pub struct LanguageClient<'a> {
   connection: &'a Connection,
@@ -147,6 +148,7 @@ language_server! {
   requests: {
     hover: HoverRequest,
     code_action: CodeActionRequest,
+    rename: RenameRequest,
   }
 }
 

--- a/lsp/src/scope.rs
+++ b/lsp/src/scope.rs
@@ -9,12 +9,14 @@ use crate::diagnostics::Diagnostic;
 use crate::diagnostics::ScopeDiagnostic;
 
 pub struct VariableUsage {
-  declaration: Option<Span>,
-  references: Vec<Span>,
+  pub declaration: Option<Span>,
+  pub references: Vec<Span>,
 }
 
+pub type Scope<'text> = HashMap<&'text str, VariableUsage>;
+
 pub struct ScopeVisitor<'text> {
-  variables: HashMap<&'text str, VariableUsage>,
+  pub variables: Scope<'text>,
   pub diagnostics: Vec<Diagnostic<'text>>,
 }
 

--- a/lsp/test/main_test.ts
+++ b/lsp/test/main_test.ts
@@ -1,5 +1,6 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import { LSPTest } from "./util/mod.ts";
+import { RequestResponse } from "./util/types.ts";
 
 Deno.test("diagnostics", async () => {
   await using lsp = new LSPTest();
@@ -192,7 +193,7 @@ Deno.test("scope diagnostics", async (t) => {
   });
 });
 
-Deno.test("variable rename", async () => {
+Deno.test("variable rename", async (t) => {
   await using lsp = new LSPTest();
   await lsp.initialize();
 
@@ -208,37 +209,107 @@ Deno.test("variable rename", async () => {
     },
   );
 
-  const response = await lsp.request("textDocument/rename", {
-    textDocument: { uri: "file:///src/main.mf2" },
-    position: { line: 0, character: 8 },
-    newName: "hello",
+  await t.step("prepare to rename from the middle of foo", async () => {
+    const response = await lsp.request("textDocument/prepareRename", {
+      textDocument: { uri: "file:///src/main.mf2" },
+      position: { line: 0, character: 10 },
+    }) as Omit<RequestResponse<"textDocument/prepareRename">, "placeholder">;
+
+    assertEquals(response, {
+      start: { character: 8, line: 0 },
+      end: { character: 11, line: 0 },
+    });
   });
 
-  assertEquals(response, {
-    changes: {
-      "file:///src/main.mf2": [
-        {
-          newText: "$hello",
-          range: {
-            start: { character: 7, line: 0 },
-            end: { character: 11, line: 0 },
+  await t.step("prepare to rename from the $", async () => {
+    const response = await lsp.request("textDocument/prepareRename", {
+      textDocument: { uri: "file:///src/main.mf2" },
+      position: { line: 0, character: 7 },
+    }) as Omit<RequestResponse<"textDocument/prepareRename">, "placeholder">;
+
+    assertEquals(response, {
+      start: { character: 8, line: 0 },
+      end: { character: 11, line: 0 },
+    });
+  });
+
+  await t.step("prepare to rename from the space before $", async () => {
+    const response = await lsp.request("textDocument/prepareRename", {
+      textDocument: { uri: "file:///src/main.mf2" },
+      position: { line: 0, character: 6 },
+    }) as Omit<RequestResponse<"textDocument/prepareRename">, "placeholder">;
+
+    assertEquals(response, null);
+  });
+
+  await t.step("prepare to rename from .local", async () => {
+    const response = await lsp.request("textDocument/prepareRename", {
+      textDocument: { uri: "file:///src/main.mf2" },
+      position: { line: 0, character: 2 },
+    }) as Omit<RequestResponse<"textDocument/prepareRename">, "placeholder">;
+
+    assertEquals(response, null);
+  });
+
+  await t.step("rename foo to hello, from the middle of foo", async () => {
+    const response = await lsp.request("textDocument/rename", {
+      textDocument: { uri: "file:///src/main.mf2" },
+      position: { line: 0, character: 10 },
+      newName: "hello",
+    });
+
+    assertEquals(response, {
+      changes: {
+        "file:///src/main.mf2": [
+          {
+            newText: "$hello",
+            range: {
+              start: { character: 7, line: 0 },
+              end: { character: 11, line: 0 },
+            },
           },
-        },
-        {
-          newText: "$hello",
-          range: {
-            start: { character: 33, line: 0 },
-            end: { character: 37, line: 0 },
+          {
+            newText: "$hello",
+            range: {
+              start: { character: 33, line: 0 },
+              end: { character: 37, line: 0 },
+            },
           },
-        },
-        {
-          newText: "$hello",
-          range: {
-            start: { character: 7, line: 2 },
-            end: { character: 11, line: 2 },
+          {
+            newText: "$hello",
+            range: {
+              start: { character: 7, line: 2 },
+              end: { character: 11, line: 2 },
+            },
           },
-        },
-      ],
-    },
+        ],
+      },
+    });
+  });
+
+  await t.step("rename the .local to hello", async () => {
+    const error = await assertRejects(() => lsp.request("textDocument/rename", {
+      textDocument: { uri: "file:///src/main.mf2" },
+      position: { line: 0, character: 2 },
+      newName: "hello",
+    }));
+
+    assertEquals(error, {
+      code: -32803,
+      message: "Error handling request textDocument/rename: No variable to rename at the given position",
+    });
+  });
+
+  await t.step("rename foo to 123, from the middle of foo", async () => {
+    const error = await assertRejects(() => lsp.request("textDocument/rename", {
+      textDocument: { uri: "file:///src/main.mf2" },
+      position: { line: 0, character: 10 },
+      newName: "123",
+    }));
+
+    assertEquals(error, {
+      code: -32803,
+      message: "Error handling request textDocument/rename: Invalid variable name",
+    });
   });
 });

--- a/lsp/test/main_test.ts
+++ b/lsp/test/main_test.ts
@@ -296,7 +296,7 @@ Deno.test("variable rename", async (t) => {
 
     assertEquals(error, {
       code: -32803,
-      message: "Error handling request textDocument/rename: No variable to rename at the given position",
+      message: "No variable to rename at the given position",
     });
   });
 
@@ -309,7 +309,7 @@ Deno.test("variable rename", async (t) => {
 
     assertEquals(error, {
       code: -32803,
-      message: "Error handling request textDocument/rename: Invalid variable name",
+      message: "Invalid variable name",
     });
   });
 });

--- a/lsp/test/main_test.ts
+++ b/lsp/test/main_test.ts
@@ -1,6 +1,5 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { LSPTest } from "./util/mod.ts";
-import { RequestResponse } from "./util/types.ts";
 
 Deno.test("diagnostics", async () => {
   await using lsp = new LSPTest();
@@ -99,8 +98,7 @@ Deno.test("scope diagnostics", async (t) => {
     assertEquals(diagnostic, {
       diagnostics: [
         {
-          message:
-            "$foo has already been declared.",
+          message: "$foo has already been declared.",
           range: {
             start: { character: 25, line: 0 },
             end: { character: 29, line: 0 },
@@ -133,8 +131,7 @@ Deno.test("scope diagnostics", async (t) => {
     assertEquals(diagnostic, {
       diagnostics: [
         {
-          message:
-            "$foo is used before it is declared.",
+          message: "$foo is used before it is declared.",
           range: {
             start: { character: 21, line: 0 },
             end: { character: 25, line: 0 },
@@ -167,8 +164,7 @@ Deno.test("scope diagnostics", async (t) => {
     assertEquals(diagnostic, {
       diagnostics: [
         {
-          message:
-            "$foo is used before it is declared.",
+          message: "$foo is used before it is declared.",
           range: {
             start: { character: 15, line: 0 },
             end: { character: 19, line: 0 },
@@ -177,8 +173,7 @@ Deno.test("scope diagnostics", async (t) => {
           source: "mf2",
         },
         {
-          message:
-            "$foo is used before it is declared.",
+          message: "$foo is used before it is declared.",
           range: {
             start: { character: 28, line: 0 },
             end: { character: 32, line: 0 },
@@ -213,7 +208,7 @@ Deno.test("variable rename", async (t) => {
     const response = await lsp.request("textDocument/prepareRename", {
       textDocument: { uri: "file:///src/main.mf2" },
       position: { line: 0, character: 10 },
-    }) as Omit<RequestResponse<"textDocument/prepareRename">, "placeholder">;
+    });
 
     assertEquals(response, {
       start: { character: 8, line: 0 },
@@ -225,7 +220,7 @@ Deno.test("variable rename", async (t) => {
     const response = await lsp.request("textDocument/prepareRename", {
       textDocument: { uri: "file:///src/main.mf2" },
       position: { line: 0, character: 7 },
-    }) as Omit<RequestResponse<"textDocument/prepareRename">, "placeholder">;
+    });
 
     assertEquals(response, {
       start: { character: 8, line: 0 },
@@ -237,7 +232,7 @@ Deno.test("variable rename", async (t) => {
     const response = await lsp.request("textDocument/prepareRename", {
       textDocument: { uri: "file:///src/main.mf2" },
       position: { line: 0, character: 6 },
-    }) as Omit<RequestResponse<"textDocument/prepareRename">, "placeholder">;
+    });
 
     assertEquals(response, null);
   });
@@ -246,7 +241,7 @@ Deno.test("variable rename", async (t) => {
     const response = await lsp.request("textDocument/prepareRename", {
       textDocument: { uri: "file:///src/main.mf2" },
       position: { line: 0, character: 2 },
-    }) as Omit<RequestResponse<"textDocument/prepareRename">, "placeholder">;
+    });
 
     assertEquals(response, null);
   });
@@ -288,28 +283,32 @@ Deno.test("variable rename", async (t) => {
   });
 
   await t.step("rename the .local to hello", async () => {
-    const error = await assertRejects(() => lsp.request("textDocument/rename", {
-      textDocument: { uri: "file:///src/main.mf2" },
-      position: { line: 0, character: 2 },
-      newName: "hello",
-    }));
+    const error = await assertRejects(() =>
+      lsp.request("textDocument/rename", {
+        textDocument: { uri: "file:///src/main.mf2" },
+        position: { line: 0, character: 2 },
+        newName: "hello",
+      })
+    );
 
     assertEquals(error, {
       code: -32803,
-      message: "No variable to rename at the given position",
+      message: "No variable to rename at the given position.",
     });
   });
 
   await t.step("rename foo to 123, from the middle of foo", async () => {
-    const error = await assertRejects(() => lsp.request("textDocument/rename", {
-      textDocument: { uri: "file:///src/main.mf2" },
-      position: { line: 0, character: 10 },
-      newName: "123",
-    }));
+    const error = await assertRejects(() =>
+      lsp.request("textDocument/rename", {
+        textDocument: { uri: "file:///src/main.mf2" },
+        position: { line: 0, character: 10 },
+        newName: "123",
+      })
+    );
 
     assertEquals(error, {
       code: -32803,
-      message: "Invalid variable name",
+      message: "Invalid variable name.",
     });
   });
 });

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -286,6 +286,12 @@ impl Spanned for Variable<'_> {
   }
 }
 
+impl Variable<'_> {
+  pub fn name_span(&self) -> Span {
+    Span::new(self.span.start + '$'..self.span.end)
+  }
+}
+
 impl<'text> Visitable<'text> for Variable<'text> {
   fn apply_visitor<'ast, V: Visit<'ast, 'text> + ?Sized>(
     &'ast self,

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -17,3 +17,10 @@ pub use visitor::{AnyNodeVisitor, Visit, Visitable};
 pub fn parse(message: &str) -> (Message, Vec<Diagnostic>, SourceTextInfo) {
   Parser::new(message).parse()
 }
+
+pub fn is_valid_name(name: &str) -> bool {
+  let mut ch_it = name.chars();
+
+  matches!(ch_it.next(), Some(chars::name_start!()))
+    && ch_it.all(|c| matches!(c, chars::name!()))
+}


### PR DESCRIPTION
TODO:
- [x] validate the new name, using https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareRename
- [x] properly return errors instead of None